### PR TITLE
Add placement and explosion metrics

### DIFF
--- a/Scripts/Player/Player.cs
+++ b/Scripts/Player/Player.cs
@@ -426,7 +426,13 @@ public partial class Player : Unit, IContainer{
             int inserted = startAmount - (s?.amount ?? 0);
             if (inserted > 0){
                 GameManager.Instance.runMetrics.itemsPickedUp += inserted;
+                GameManager.Instance.myMetrics.itemsPickedUp += inserted;
                 GameManager.Instance.runMetrics.AddDiscoveredItem(itemId);
+                GameManager.Instance.myMetrics.AddDiscoveredItem(itemId);
+
+                if (itemId == "Corbydine Core"){
+                    GameManager.Instance.UnlockAchievement("CORE");
+                }
             }
         }
 
@@ -550,10 +556,16 @@ public partial class Player : Unit, IContainer{
     private float footstepDist = 1.8f;
 
     private void FixedUpdate(){
-        if (m_Grounded){
+            if (m_Grounded){
             float delta = Vector3.Distance(transform.position, prevPos);
             distMoved += delta;
             GameManager.Instance.runMetrics.distanceTraveled += delta;
+            GameManager.Instance.myMetrics.distanceTraveled += delta;
+
+            float totalDistance = GameManager.Instance.myMetrics.distanceTraveled;
+            if (totalDistance >= 42190f){
+                GameManager.Instance.UnlockAchievement("MARATHON");
+            }
         }
         prevPos = transform.position;
 

--- a/Scripts/Systems/GameManager.cs
+++ b/Scripts/Systems/GameManager.cs
@@ -215,6 +215,9 @@ public class GameManager : MonoBehaviour{
         if (TerrainManager.Instance != null && save){
             Save();
         }
+        else{
+            SyncStatsWithSteam();
+        }
 
         LoadTitleScreen();
     }
@@ -367,6 +370,7 @@ public class GameManager : MonoBehaviour{
         PlayerPrefs.SetString("PlayerStats", json);
 
         PlayerPrefs.Save();
+        SyncStatsWithSteam();
     }
 
     public void LoadStats(){
@@ -388,8 +392,21 @@ public class GameManager : MonoBehaviour{
             currentWorld.worldMetrics += runMetrics;
         }
 
-        myMetrics += runMetrics;
         runMetrics = new WorldMetrics();
+    }
+
+    public void SyncStatsWithSteam(){
+#if STEAMWORKS1
+        WorldMetrics total = myMetrics + runMetrics;
+        Steamworks.SteamUserStats.SetStat("BlocksBroken", total.blocksBroken);
+        Steamworks.SteamUserStats.SetStat("BlocksPlaced", total.blocksPlaced);
+        Steamworks.SteamUserStats.SetStat("TerrainDestroyed", total.terrainDestroyed);
+        Steamworks.SteamUserStats.SetStat("ItemsPickedUp", total.itemsPickedUp);
+        Steamworks.SteamUserStats.SetStat("MoneyEarned", total.moneyEarned);
+        Steamworks.SteamUserStats.SetStat("DistanceTraveled", total.distanceTraveled);
+        Steamworks.SteamUserStats.SetStat("CurrentRunMoney", runMetrics.moneyEarned);
+        Steamworks.SteamUserStats.StoreStats();
+#endif
     }
 
     public bool DeleteWorld(World world){
@@ -446,6 +463,7 @@ public class GameManager : MonoBehaviour{
             ClearAchievement(achievement);
         }
     }
+
 
     public void ToggleSettings(){
         settingsWindow.Toggle();

--- a/Scripts/Systems/Items/ItemClasses/BlockItem.cs
+++ b/Scripts/Systems/Items/ItemClasses/BlockItem.cs
@@ -16,7 +16,11 @@ namespace Systems.Items{
                 if (slot.ItemStack.amount <= 0){
                     slot.ItemStack = null;
                 }
-                
+
+                if (user is Player){
+                    GameManager.Instance.runMetrics.blocksPlaced += 1;
+                    GameManager.Instance.myMetrics.blocksPlaced += 1;
+                }
             }
         }
 

--- a/Scripts/Systems/Round/RoundManager.cs
+++ b/Scripts/Systems/Round/RoundManager.cs
@@ -157,7 +157,7 @@ namespace Systems.Round{
 
         public void AddMoney(int amount, bool countTowardsQuota = true){
             money += amount;
-            
+
             GameManager.Instance.runMetrics.moneyEarned += amount;
             GameManager.Instance.myMetrics.moneyEarned += amount;
 

--- a/Scripts/Systems/Round/RoundManager.cs
+++ b/Scripts/Systems/Round/RoundManager.cs
@@ -159,6 +159,13 @@ namespace Systems.Round{
             money += amount;
             
             GameManager.Instance.runMetrics.moneyEarned += amount;
+            GameManager.Instance.myMetrics.moneyEarned += amount;
+
+            int totalMoney = GameManager.Instance.myMetrics.moneyEarned;
+            if (totalMoney >= 100000){
+                GameManager.Instance.UnlockAchievement("100000_DOLLARS");
+            }
+
             if (amount > 0){
                 Player.Instance.Popup("+" + amount + "$", new Color(0.1f, 1f, 0.5f));
             }

--- a/Scripts/Systems/Terrain/TerrainManager.cs
+++ b/Scripts/Systems/Terrain/TerrainManager.cs
@@ -122,6 +122,9 @@ public partial class TerrainManager : MonoBehaviour{
             return;
         wallTilemap.SetTile(pos, null);
         Instantiate(blockDebrisPrefab, pos, Quaternion.identity);
+
+        GameManager.Instance.runMetrics.terrainDestroyed += 1;
+        GameManager.Instance.myMetrics.terrainDestroyed += 1;
     }
 
 
@@ -208,6 +211,12 @@ public partial class TerrainManager : MonoBehaviour{
         }
 
         GameManager.Instance.runMetrics.blocksBroken += 1;
+        GameManager.Instance.myMetrics.blocksBroken += 1;
+
+        int totalBlocks = GameManager.Instance.myMetrics.blocksBroken;
+        if (totalBlocks >= 100){
+            GameManager.Instance.UnlockAchievement("DESTRUCTION");
+        }
 
         return true;
     }
@@ -592,14 +601,22 @@ public partial class TerrainManager : MonoBehaviour{
         for (int i = -halfX; i < halfX; i++){
             for (int j = -halfY; j < halfY; j++){
                 Vector3Int pos = new Vector3Int(i, j, 0);
-                bool hasWall = wallTilemap.GetTile(pos) != null;
+                TileBase tile = wallTilemap.GetTile(pos);
 
                 // Calculate 1D index
                 int xIndex = i + halfX;
                 int yIndex = j + halfY;
                 int flatIndex = yIndex * GameManager.Instance.currentWorld.worldSize.x + xIndex;
 
-                GameManager.Instance.currentWorld.walls[flatIndex] = (short)( hasWall ? 1:-1);
+                short index = 0;
+                if (tile != null){
+                    int regIndex = wallTilesRegistry.IndexOf(tile);
+                    if (regIndex >= 0){
+                        index = (short)(regIndex + 1);
+                    }
+                }
+
+                GameManager.Instance.currentWorld.walls[flatIndex] = index;
             }
         }
 
@@ -623,9 +640,9 @@ public partial class TerrainManager : MonoBehaviour{
                 int yIndex = j + halfY;
                 int flatIndex = yIndex * GameManager.Instance.currentWorld.worldSize.x + xIndex;
 
-                bool hasWall = GameManager.Instance.currentWorld.walls[flatIndex] >0;
-                if (hasWall){
-                    SetWall(GameManager.Instance.currentWorld.walls[flatIndex], pos);
+                short wallIndex = GameManager.Instance.currentWorld.walls[flatIndex];
+                if (wallIndex > 0){
+                    SetWall(wallIndex, pos);
                 }
             }
         }

--- a/Scripts/Systems/Terrain/TerrainManager.cs
+++ b/Scripts/Systems/Terrain/TerrainManager.cs
@@ -218,6 +218,12 @@ public partial class TerrainManager : MonoBehaviour{
             GameManager.Instance.UnlockAchievement("DESTRUCTION");
         }
 
+        int totalBlocks = GameManager.Instance.myMetrics.blocksBroken +
+                         GameManager.Instance.runMetrics.blocksBroken;
+        if (totalBlocks >= 100){
+            GameManager.Instance.UnlockAchievement("DESTRUCTION");
+        }
+
         return true;
     }
 

--- a/Scripts/WorldMetrics.cs
+++ b/Scripts/WorldMetrics.cs
@@ -9,6 +9,8 @@ using Newtonsoft.Json;
 public class WorldMetrics
 {
     public int blocksBroken;
+    public int blocksPlaced;
+    public int terrainDestroyed;
     public int itemsPickedUp;
     public int moneyEarned;
     public float distanceTraveled;
@@ -17,6 +19,8 @@ public class WorldMetrics
     public WorldMetrics()
     {
         blocksBroken = 0;
+        blocksPlaced = 0;
+        terrainDestroyed = 0;
         itemsPickedUp = 0;
         moneyEarned = 0;
         distanceTraveled = 0f;


### PR DESCRIPTION
## Summary
- track blocks placed and terrain destroyed
- count player placements in `BlockItem`
- record wall destruction stats
- sync new totals with Steam
- fix wall saving to preserve wall tile type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686bf61eb16083298026981d7bafa16b