### PR TITLE
Fix metric syncing across runs

### DIFF
--- a/Scripts/Player/Player.cs
+++ b/Scripts/Player/Player.cs
@@ -364,6 +364,7 @@ public partial class Player : Unit, IContainer{
                        bool removed= TerrainManager.Instance.RemoveBlock(myCursor.currentPos);
                        if (removed){
                            GameManager.Instance.runMetrics.blocksBroken += 1;
+                           GameManager.Instance.myMetrics.blocksBroken += 1;
 
                        }
                     }
@@ -430,7 +431,9 @@ public partial class Player : Unit, IContainer{
             int inserted = startAmount - (s?.amount ?? 0);
             if (inserted > 0){
                 GameManager.Instance.runMetrics.itemsPickedUp += inserted;
+                GameManager.Instance.myMetrics.itemsPickedUp += inserted;
                 GameManager.Instance.runMetrics.AddDiscoveredItem(itemId);
+                GameManager.Instance.myMetrics.AddDiscoveredItem(itemId);
 
                 if (itemId == "Corbydine Core"){
                     GameManager.Instance.UnlockAchievement("CORE");
@@ -562,6 +565,7 @@ public partial class Player : Unit, IContainer{
             float delta = Vector3.Distance(transform.position, prevPos);
             distMoved += delta;
             GameManager.Instance.runMetrics.distanceTraveled += delta;
+            GameManager.Instance.myMetrics.distanceTraveled += delta;
 
             float totalDistance = GameManager.Instance.myMetrics.distanceTraveled +
                                  GameManager.Instance.runMetrics.distanceTraveled;

--- a/Scripts/Systems/GameManager.cs
+++ b/Scripts/Systems/GameManager.cs
@@ -396,19 +396,20 @@ public class GameManager : MonoBehaviour{
             currentWorld.worldMetrics += runMetrics;
         }
 
-        myMetrics += runMetrics;
         runMetrics = new WorldMetrics();
     }
 
     public void SyncStatsWithSteam(){
 #if STEAMWORKS1
-        WorldMetrics total = myMetrics + runMetrics;
+        WorldMetrics total = myMetrics;
         Steamworks.SteamUserStats.SetStat("BlocksBroken", total.blocksBroken);
+        Steamworks.SteamUserStats.SetStat("BlocksPlaced", total.blocksPlaced);
+        Steamworks.SteamUserStats.SetStat("TerrainDestroyed", total.terrainDestroyed);
         Steamworks.SteamUserStats.SetStat("ItemsPickedUp", total.itemsPickedUp);
         Steamworks.SteamUserStats.SetStat("MoneyEarned", total.moneyEarned);
         Steamworks.SteamUserStats.SetStat("DistanceTraveled", total.distanceTraveled);
-        
-        Steamworks.SteamUserStats.SetStat("CurrentMoneyEarned",runMetrics.moneyEarned);
+
+        Steamworks.SteamUserStats.SetStat("CurrentRunMoney",runMetrics.moneyEarned);
         Steamworks.SteamUserStats.StoreStats();
 #endif
     }

--- a/Scripts/Systems/Items/ItemClasses/BlockItem.cs
+++ b/Scripts/Systems/Items/ItemClasses/BlockItem.cs
@@ -12,11 +12,13 @@ namespace Systems.Items{
         public override void Use(Vector2Int pos, Unit user, Slot slot){
             base.Use(pos, user,slot);
             if (TerrainManager.Instance.PlaceBlock(blockPrefab, pos,  Cursor.Instance.cursorRotation, makeSound:true)){
+                GameManager.Instance.runMetrics.blocksPlaced += 1;
+                GameManager.Instance.myMetrics.blocksPlaced += 1;
                 slot.ItemStack.amount--;
                 if (slot.ItemStack.amount <= 0){
                     slot.ItemStack = null;
                 }
-                
+
             }
         }
 

--- a/Scripts/Systems/Round/RoundManager.cs
+++ b/Scripts/Systems/Round/RoundManager.cs
@@ -159,6 +159,7 @@ namespace Systems.Round{
             money += amount;
             
             GameManager.Instance.runMetrics.moneyEarned += amount;
+            GameManager.Instance.myMetrics.moneyEarned += amount;
 
             int totalMoney = GameManager.Instance.myMetrics.moneyEarned +
                              GameManager.Instance.runMetrics.moneyEarned;

--- a/Scripts/Systems/Terrain/TerrainManager.cs
+++ b/Scripts/Systems/Terrain/TerrainManager.cs
@@ -122,6 +122,8 @@ public partial class TerrainManager : MonoBehaviour{
             return;
         wallTilemap.SetTile(pos, null);
         Instantiate(blockDebrisPrefab, pos, Quaternion.identity);
+        GameManager.Instance.runMetrics.terrainDestroyed += 1;
+        GameManager.Instance.myMetrics.terrainDestroyed += 1;
     }
 
 
@@ -592,14 +594,20 @@ public partial class TerrainManager : MonoBehaviour{
         for (int i = -halfX; i < halfX; i++){
             for (int j = -halfY; j < halfY; j++){
                 Vector3Int pos = new Vector3Int(i, j, 0);
-                bool hasWall = wallTilemap.GetTile(pos) != null;
 
                 // Calculate 1D index
                 int xIndex = i + halfX;
                 int yIndex = j + halfY;
                 int flatIndex = yIndex * GameManager.Instance.currentWorld.worldSize.x + xIndex;
 
-                GameManager.Instance.currentWorld.walls[flatIndex] = (short)( hasWall ? 1:-1);
+                TileBase tile = wallTilemap.GetTile(pos);
+                int tileIndex = 0;
+                if (tile != null){
+                    int idx = wallTilesRegistry.IndexOf(tile);
+                    tileIndex = idx >= 0 ? idx + 1 : 0;
+                }
+
+                GameManager.Instance.currentWorld.walls[flatIndex] = (short)tileIndex;
             }
         }
 
@@ -623,9 +631,9 @@ public partial class TerrainManager : MonoBehaviour{
                 int yIndex = j + halfY;
                 int flatIndex = yIndex * GameManager.Instance.currentWorld.worldSize.x + xIndex;
 
-                bool hasWall = GameManager.Instance.currentWorld.walls[flatIndex] >0;
-                if (hasWall){
-                    SetWall(GameManager.Instance.currentWorld.walls[flatIndex], pos);
+                short index = GameManager.Instance.currentWorld.walls[flatIndex];
+                if (index > 0){
+                    SetWall(index, pos);
                 }
             }
         }

--- a/Scripts/WorldMetrics.cs
+++ b/Scripts/WorldMetrics.cs
@@ -9,6 +9,8 @@ using Newtonsoft.Json;
 public class WorldMetrics
 {
     public int blocksBroken;
+    public int blocksPlaced;
+    public int terrainDestroyed;
     public int itemsPickedUp;
     public int moneyEarned;
     public float distanceTraveled;
@@ -17,6 +19,8 @@ public class WorldMetrics
     public WorldMetrics()
     {
         blocksBroken = 0;
+        blocksPlaced = 0;
+        terrainDestroyed = 0;
         itemsPickedUp = 0;
         moneyEarned = 0;
         distanceTraveled = 0f;


### PR DESCRIPTION
## Summary
- adjust ApplyRunMetrics so global stats aren't double counted
- send CurrentRunMoney stat to Steam and update global totals correctly
- count player actions in both run and global metrics
- track blocks placed and terrain destroyed
- fix saving wall tile types so ice walls load correctly

## Testing
- `echo "No tests defined"`


------
https://chatgpt.com/codex/tasks/task_e_686c719260e88329b3b0624b974762f7