### PR TITLE
Improve world save performance

### DIFF
--- a/Scripts/Systems/GameManager.cs
+++ b/Scripts/Systems/GameManager.cs
@@ -20,6 +20,7 @@ using UnityEngine;
 using UnityEngine.Localization.Settings;
 using UnityEngine.SceneManagement;
 using UnityEngine.Serialization;
+using System.Threading.Tasks;
 using Random = UnityEngine.Random;
 using Terrain = Systems.Terrain.Terrain;
 
@@ -287,26 +288,20 @@ public class GameManager : MonoBehaviour{
         saveIconCG.alpha = 1;
         string settingsJSON = JsonConvert.SerializeObject(settings, JSONsettings);
         PlayerPrefs.SetString("GameSettings", settingsJSON);
-        
-        
+
+
         SaveStats();
 
         try{
             Debug.Log("Saving World");
 
-            //player save
             if (Player.Instance)
                 currentWorld.playerData = Player.Instance.SavePlayer();
             Debug.Log("saved:" + JsonConvert.SerializeObject(currentWorld.playerData, JSONsettings));
 
-            //round save
             if (RoundManager.Instance)
                 currentWorld.roundData = RoundManager.Instance.SaveRoundData();
-        }
-        catch (Exception e){
-            Debug.LogError($"Failed to save world: {e.StackTrace}");
-        }
-            // Save the current world data
+
             yield return StartCoroutine(TerrainManager.Instance.SaveWorldCR());
 
             // Check if the current world is already in the list
@@ -324,36 +319,41 @@ public class GameManager : MonoBehaviour{
 
             // Save the current world to PlayerPrefs
 
-            string json = "";
+            System.Threading.Tasks.Task<string> serializeTask;
 #if UNITYSERIALIZATION1
-         json = JsonUtility.ToJson(currentWorld, true);
+            serializeTask = System.Threading.Tasks.Task.Run(() => JsonUtility.ToJson(currentWorld, true));
 #else
-            json = JsonConvert.SerializeObject(currentWorld, Formatting.Indented, JSONsettings);
+            serializeTask = System.Threading.Tasks.Task.Run(() => JsonConvert.SerializeObject(currentWorld, Formatting.Indented, JSONsettings));
 #endif
-            //string json = JsonUtility.ToJson(currentWorld);
+
+            while(!serializeTask.IsCompleted) yield return null;
+            string json = serializeTask.Result;
             PlayerPrefs.SetString(currentWorld.name, json);
-            
+
 
 #if UNITY_STANDALONE_WIN
             try{
                 string filePath = Path.Combine(Application.persistentDataPath, "WorldSave.txt");
-                string jsonPretty = json;
-                //string jsonPretty = json; // Enable pretty print
-                File.WriteAllText(filePath, jsonPretty);
+                var fileTask = System.Threading.Tasks.Task.Run(() => File.WriteAllText(filePath, json));
+                while(!fileTask.IsCompleted) yield return null;
                 Debug.Log($"World saved to text file at {filePath}");
             }
             catch (Exception e){
-                Debug.LogError($"Failed to save world to text file: {e.StackTrace}");
+                Debug.LogError($"Failed to save world to text file: {e}");
             }
 #endif
 
             SaveWorlds();
 
             Debug.Log("finished saving saved:" + JsonConvert.SerializeObject(currentWorld.playerData, JSONsettings));
-        
-
-        saveIconCG.alpha = 0;
-        yield return null;
+        }
+        catch (Exception e){
+            Debug.LogError($"Failed during save: {e}");
+        }
+        finally{
+            saveIconCG.alpha = 0;
+        }
+        yield break;
     }
 
     public void Save(){

--- a/Scripts/Systems/Terrain/TerrainGenerator.cs
+++ b/Scripts/Systems/Terrain/TerrainGenerator.cs
@@ -256,17 +256,38 @@ public partial class TerrainManager{
 
         Debug.Log($"Terrain generation took {Time.realtimeSinceStartup - terrainStartTime} seconds");
 
-        // Central area generation
-        bool inverse = centerNoise < 0.5f;
-        int a = 20;
-        for (int i = -a - 4; i <= a + 4; i++){
-            for (int j = -a - 4; j <= a + 4; j++){
-                float perlin2 = Mathf.PerlinNoise(i * 0.095f + noiseOffset * 3, j * 0.09f + noiseOffset)
-                                + Random.Range(-0.01f, 0.01f) + j / 1000f;
-                float myDist = Mathf.Sqrt(i * i + j * (j / 2));
-                float myPerlin = perlin2 + (inverse ? myDist : -myDist) / (a * 2);
-                if (inverse ? myPerlin < 0.75f : myPerlin > 0.25f){
+        // Improved spawn wall carving
+        int spawnRadius = 20;
+        FastNoiseLite carveNoise = new FastNoiseLite(currentSeed);
+        carveNoise.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+        carveNoise.SetFrequency(0.07f);
+
+        for (int i = -spawnRadius; i <= spawnRadius; i++){
+            for (int j = -spawnRadius; j <= spawnRadius; j++){
+                float dist = Mathf.Sqrt(i * i + j * j * 0.5f);
+                float noiseVal = (carveNoise.GetNoise(i, j) + 1) * 0.5f; //0-1
+                float edge = Mathf.Lerp(spawnRadius - 4, spawnRadius, noiseVal);
+                if (dist <= edge){
                     SetWall(null, new Vector3Int(i, j, 0));
+                }
+            }
+        }
+
+        // Ensure spawn terrain has no colliders (approx 5x5 area)
+        int clearRadius = 2;
+        for (int i = -clearRadius; i <= clearRadius; i++){
+            for (int j = -clearRadius; j <= clearRadius; j++){
+                Vector2Int pos = new Vector2Int(i, j);
+                TerrainProperties props = GetTerrainProperties(pos);
+                if (props != null && props.collider){
+                    Biome biome = GetBiomeForPosition(i, j);
+                    TerrainProperties replacement = Grass;
+                    if (biome != null){
+                        var choice = biome.terrains.OrderByDescending(t => t.priority)
+                                                .FirstOrDefault(t => !t.terrain.collider);
+                        if (choice != null) replacement = choice.terrain;
+                    }
+                    SetTerrain(pos, replacement);
                 }
             }
         }
@@ -526,4 +547,10 @@ public partial class TerrainManager{
             return 0;
         }
     }
-}
+
+    private Biome GetBiomeForPosition(int x, int y){
+        foreach (var b in biomes){
+            if (CheckThreshold(b.threshold, x, y)) return b;
+        }
+        return null;
+    }}

--- a/Scripts/Systems/Terrain/TerrainManager.cs
+++ b/Scripts/Systems/Terrain/TerrainManager.cs
@@ -20,6 +20,8 @@ using Vector3 = UnityEngine.Vector3;
 public partial class TerrainManager : MonoBehaviour{
     public static TerrainManager Instance;
 
+    private const float SAVE_YIELD_TIME = 0.02f;
+
     [Header("Manager Stuff:")] private Layer<Block> blockLayer;
     private Layer<Terrain> terrainLayer;
     private Layer<Ore> oreLayer;
@@ -548,7 +550,7 @@ public partial class TerrainManager : MonoBehaviour{
         }
 
 
-        int counter = 0;
+        float lastYield = Time.realtimeSinceStartup;
         //possibly a bad idea to clone list, but avoids issues when saving
         foreach (var block in blockLayer.GetDictionary().Values.ToList()){
             if (!block.hasSaved){
@@ -559,13 +561,15 @@ public partial class TerrainManager : MonoBehaviour{
                 GameManager.Instance.currentWorld.blocks.Add(blockData);
                 block.hasSaved = true;
             }
-            if (++counter % 50 == 0) yield return null;
+            if (Time.realtimeSinceStartup - lastYield > SAVE_YIELD_TIME){
+                lastYield = Time.realtimeSinceStartup;
+                yield return null;
+            }
         }
 
         Debug.Log("Saved Blocks");
 
         GameManager.Instance.currentWorld.ores.Clear();
-        counter = 0;
         foreach (var pair in oreLayer.GetDictionary()){
             OreData data = new OreData{
                 position = pair.Key,
@@ -573,18 +577,23 @@ public partial class TerrainManager : MonoBehaviour{
                 amount = pair.Value.amount
             };
             GameManager.Instance.currentWorld.ores.Add(data);
-            if (++counter % 200 == 0) yield return null;
+            if (Time.realtimeSinceStartup - lastYield > SAVE_YIELD_TIME){
+                lastYield = Time.realtimeSinceStartup;
+                yield return null;
+            }
         }
 
         // Save terrain
         GameManager.Instance.currentWorld.terrain.Clear();
-        counter = 0;
         foreach (var pair in terrainLayer.GetDictionary()){
             GameManager.Instance.currentWorld.terrain.Add(new TerrainData{
                 pos = pair.Key,
                 t = pair.Value // Store the asset name
             });
-            if (++counter % 200 == 0) yield return null;
+            if (Time.realtimeSinceStartup - lastYield > SAVE_YIELD_TIME){
+                lastYield = Time.realtimeSinceStartup;
+                yield return null;
+            }
         }
 
 
@@ -614,8 +623,12 @@ public partial class TerrainManager : MonoBehaviour{
                 }
 
                 GameManager.Instance.currentWorld.walls[flatIndex] = (short)tileIndex;
+
+                if (Time.realtimeSinceStartup - lastYield > SAVE_YIELD_TIME){
+                    lastYield = Time.realtimeSinceStartup;
+                    yield return null;
+                }
             }
-            if (i % 10 == 0) yield return null;
         }
 
 


### PR DESCRIPTION
## Summary
- reduce yield frequency in TerrainManager with SAVE_YIELD_TIME constant
- serialize world data asynchronously to avoid main-thread stalls
- refine spawn clearing to avoid colliders and shape walls naturally

## Testing
- `echo "No tests to run"`


------
https://chatgpt.com/codex/tasks/task_e_686d70b50274832998f694ea77d4def9